### PR TITLE
Ensure that Async HTTPX connections are closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Updated the supported version of httpx
+- Changed the close behaviour of AsyncHTTPRequest to use `aclose()` rather than `close()` as per 
+(https://www.python-httpx.org/async/#opening-and-closing-clients) 
 
 ## [1.1.0] - 2020-03-30
 - Added [Server-side Experiments](https://developers.google.com/optimize/devguides/experiments) alias [issues-4]

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     keywords=["python", "analytics", "google-analytics"],
-    install_requires=["httpx>=0.7.7"],
+    install_requires=["httpx>=0.10.0"],
     setup_requires=["pytest-runner", "flake8"],
     tests_require=["coverage", "pytest", "pytest-asyncio", "asynctest"],
     cmdclass={"release": ReleaseCommand}

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -61,7 +61,7 @@ class TestAsyncHTTPRequest:
     @pytest.fixture
     def session(self):
         return mock.Mock(post=asynctest.CoroutineMock(),
-                         close=asynctest.CoroutineMock())
+                         aclose=asynctest.CoroutineMock())
 
     @pytest.mark.asyncio
     async def test_http_request(self, session):
@@ -76,7 +76,7 @@ class TestAsyncHTTPRequest:
     async def test_http_request_close_session(self, session):
         async with requests.AsyncHTTPRequest(session=session):
             pass
-        session.close.assert_called()
+        session.aclose.assert_called()
 
     @pytest.mark.asyncio
     async def test_http_batch_request(self, session):
@@ -108,5 +108,5 @@ class TestAsyncHTTPRequest:
         http._send = mocked__send
         await http.close()
 
-        session.close.assert_called()
+        session.aclose.assert_called()
         mocked__send.assert_called()

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -165,7 +165,7 @@ class TestTracker:
     @pytest.mark.asyncio
     async def test_send_with_async_request(self):
         session = mock.Mock(post=asynctest.CoroutineMock(),
-                            close=asynctest.CoroutineMock())
+                            aclose=asynctest.CoroutineMock())
         async with AsyncHTTPRequest(session=session) as http:
             t = tracker.Tracker("UA-XXXXX-Y", http)
             await t.send("pageview", "/test")

--- a/universal_analytics/requests.py
+++ b/universal_analytics/requests.py
@@ -127,7 +127,7 @@ class AsyncHTTPRequest(BaseHTTPRequest):
         await self.session.post(self.endpoint, data=payload)
 
     async def close(self):
-        await self.session.close()
+        await self.session.aclose()
 
 
 class AsyncHTTPBatchRequest(AsyncHTTPRequest):


### PR DESCRIPTION
According to the documentation at https://www.python-httpx.org/async/#opening-and-closing-clients the closing of an asynchronous HTTPX connection should use `aclose()`. However the existing context manager for AsyncHTTPRequest attempts to call a method close() that is not implemented and results in a warning:

`AttributeError: 'AsyncClient' object has no attribute 'close' .../lib/python3.7/site-packages/httpx/_client.py:1773: UserWarning: Unclosed <httpx.AsyncClient object at 0x10b524710>. See https://www.python-httpx.org/async/#opening-and-closing-clients for details.`

This PR changes the function call from `close()` to `aclose()` removing the warning and ensuring that all http connections are closed.